### PR TITLE
fix: 알림 시간 초기화 쿼리 수정

### DIFF
--- a/app/domain/ticketing-domain/src/main/java/org/example/repository/ticketingalert/TicketingAlertRepository.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/repository/ticketingalert/TicketingAlertRepository.java
@@ -1,5 +1,6 @@
 package org.example.repository.ticketingalert;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.example.entity.TicketingAlert;
@@ -12,5 +13,5 @@ public interface TicketingAlertRepository extends JpaRepository<TicketingAlert, 
         UUID showId
     );
 
-    List<TicketingAlert> findAllByIsDeletedFalse();
+    List<TicketingAlert> findAllByIsDeletedFalseAndAlertTimeAfter(LocalDateTime alertTime);
 }

--- a/app/domain/ticketing-domain/src/main/java/org/example/usecase/TicketingAlertUseCase.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/usecase/TicketingAlertUseCase.java
@@ -22,7 +22,7 @@ public class TicketingAlertUseCase {
 
     public List<TicketingAlertToSchedulerDomainResponse> findAllTicketingAlerts() {
         Map<TicketingAlertTargetDomainResponse, List<LocalDateTime>> groupedAlerts =
-            ticketingAlertRepository.findAllByIsDeletedFalse()
+            ticketingAlertRepository.findAllByIsDeletedFalseAndAlertTimeAfter(LocalDateTime.now())
                 .stream()
                 .collect(Collectors.groupingBy(
                     TicketingAlertTargetDomainResponse::from,


### PR DESCRIPTION
## 😋 작업한 내용

- 서버 다운 후 알림 목록을 초기화 시킬 떄, 현재 시간보다 알림 시간이 이후인 것만 조회하도록 변경했습니다. 

## 🙏 PR Point
 
- 단순 쿼리 수정으로 바로 머지하겠습니다.

## 👍 관련 이슈

- Resolved : #


---