### PR TITLE
feat: userFcmToken 변경 시 구독 목록 수정

### DIFF
--- a/app/api/common-api/src/main/java/org/example/config/UserApiConfig.java
+++ b/app/api/common-api/src/main/java/org/example/config/UserApiConfig.java
@@ -1,0 +1,41 @@
+package org.example.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.util.ErrorHandler;
+
+@Configuration
+@Import(PubSubConfig.class)
+@RequiredArgsConstructor
+public class UserApiConfig {
+
+    private final MessageListener updateUserFcmTokenListener;
+    private final ErrorHandler redisSubErrorHandler;
+
+
+    @Bean
+    MessageListenerAdapter updateUserFcmTokenListenerAdapter() {
+        return new MessageListenerAdapter(updateUserFcmTokenListener);
+    }
+
+    @Bean
+    RedisMessageListenerContainer updateUserFcmTokenListenerContainer(
+        RedisConnectionFactory connectionFactory,
+        MessageListenerAdapter updateUserFcmTokenListenerAdapter
+    ) {
+
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(updateUserFcmTokenListenerAdapter,
+            ChannelTopic.of("userFcmToken"));
+        container.setErrorHandler(redisSubErrorHandler);
+        return container;
+    }
+}

--- a/app/api/common-api/src/main/java/org/example/config/UserApiConfig.java
+++ b/app/api/common-api/src/main/java/org/example/config/UserApiConfig.java
@@ -21,12 +21,12 @@ public class UserApiConfig {
 
 
     @Bean
-    MessageListenerAdapter updateUserFcmTokenListenerAdapter() {
+    public MessageListenerAdapter updateUserFcmTokenListenerAdapter() {
         return new MessageListenerAdapter(updateUserFcmTokenListener);
     }
 
     @Bean
-    RedisMessageListenerContainer updateUserFcmTokenListenerContainer(
+    public RedisMessageListenerContainer updateUserFcmTokenListenerContainer(
         RedisConnectionFactory connectionFactory,
         MessageListenerAdapter updateUserFcmTokenListenerAdapter
     ) {

--- a/app/api/common-api/src/main/java/org/example/conver/MessageConverter.java
+++ b/app/api/common-api/src/main/java/org/example/conver/MessageConverter.java
@@ -1,0 +1,26 @@
+package org.example.conver;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+
+@UtilityClass
+@Slf4j
+public class MessageConverter {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static <T> T convertMessage(Message message, Class<T> targetType) {
+        try {
+            T convertedMessage = objectMapper.readValue(message.getBody(), targetType);
+            log.info("Message published successfully to topic: {}", new String(message.getChannel()));
+            log.info("Subscribe Message Contents ( {} : {} )", targetType.getName(), message);
+            return convertedMessage;
+        } catch (IOException e) {
+            log.error("Failed to convert message to {}", targetType.getName(), e);
+            throw new IllegalArgumentException("메시지를 받지 못했습니다.");
+        }
+    }
+}

--- a/app/api/common-api/src/main/java/org/example/conver/UserMessageConverter.java
+++ b/app/api/common-api/src/main/java/org/example/conver/UserMessageConverter.java
@@ -1,0 +1,14 @@
+package org.example.conver;
+
+import lombok.experimental.UtilityClass;
+import org.example.conver.message.UserFcmTokenMessage;
+import org.springframework.data.redis.connection.Message;
+
+@UtilityClass
+public class UserMessageConverter {
+
+    public UserFcmTokenMessage toUserFcmMessage(Message message) {
+        return MessageConverter.convertMessage(message, UserFcmTokenMessage.class);
+    }
+
+}

--- a/app/api/common-api/src/main/java/org/example/conver/message/UserFcmTokenMessage.java
+++ b/app/api/common-api/src/main/java/org/example/conver/message/UserFcmTokenMessage.java
@@ -1,0 +1,11 @@
+package org.example.conver.message;
+
+import java.util.UUID;
+
+public record UserFcmTokenMessage(
+    UUID userId,
+    String previousFcmToken,
+    String updatedFcmToken
+) {
+
+}

--- a/app/api/common-api/src/main/java/org/example/listner/UpdateUserFcmTokenListener.java
+++ b/app/api/common-api/src/main/java/org/example/listner/UpdateUserFcmTokenListener.java
@@ -1,0 +1,26 @@
+package org.example.listner;
+
+import lombok.RequiredArgsConstructor;
+import org.example.conver.UserMessageConverter;
+import org.example.metric.MessageQueueSubMonitored;
+import org.example.service.UserSubscriptionService;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+@Qualifier(value = "updateUserFcmTokenListener")
+public class UpdateUserFcmTokenListener implements MessageListener {
+
+    private final UserSubscriptionService userSubscriptionServiceImpl;
+
+    @Override
+    @MessageQueueSubMonitored(topic = "updateUserFcmToken")
+    public void onMessage(Message message, byte[] pattern) {
+        var request = UserMessageConverter.toUserFcmMessage(message);
+
+        userSubscriptionServiceImpl.updateUserFcmToken(request);
+    }
+}

--- a/app/api/common-api/src/main/java/org/example/service/UserSubscriptionService.java
+++ b/app/api/common-api/src/main/java/org/example/service/UserSubscriptionService.java
@@ -1,0 +1,8 @@
+package org.example.service;
+
+import org.example.conver.message.UserFcmTokenMessage;
+
+public interface UserSubscriptionService {
+
+    void updateUserFcmToken(UserFcmTokenMessage request);
+}

--- a/app/api/subscription-api/src/main/java/org/example/config/SubscriptionApiConfig.java
+++ b/app/api/subscription-api/src/main/java/org/example/config/SubscriptionApiConfig.java
@@ -31,37 +31,37 @@ public class SubscriptionApiConfig {
 
 
     @Bean
-    MessageListenerAdapter registerShowMessageListenerAdapter() {
+    public MessageListenerAdapter registerShowMessageListenerAdapter() {
         return new MessageListenerAdapter(registerShowMessageListener);
     }
 
     @Bean
-    MessageListenerAdapter updateShowMessageListenerAdapter() {
+    public MessageListenerAdapter updateShowMessageListenerAdapter() {
         return new MessageListenerAdapter(updateShowMessageListener);
     }
 
     @Bean
-    MessageListenerAdapter subscriptionArtistMessageListerAdapter() {
+    public MessageListenerAdapter subscriptionArtistMessageListerAdapter() {
         return new MessageListenerAdapter(subscriptionArtistMessageListener);
     }
 
     @Bean
-    MessageListenerAdapter unsubscriptionArtistMessageListerAdapter() {
+    public MessageListenerAdapter unsubscriptionArtistMessageListerAdapter() {
         return new MessageListenerAdapter(unsubscriptionArtistMessageListener);
     }
 
     @Bean
-    MessageListenerAdapter subscriptionGenreMessageListerAdapter() {
+    public MessageListenerAdapter subscriptionGenreMessageListerAdapter() {
         return new MessageListenerAdapter(subscriptionGenreMessageListener);
     }
 
     @Bean
-    MessageListenerAdapter unsubscriptionGenreMessageListerAdapter() {
+    public MessageListenerAdapter unsubscriptionGenreMessageListerAdapter() {
         return new MessageListenerAdapter(unsubscriptionGenreMessageListener);
     }
 
     @Bean
-    RedisMessageListenerContainer registerShowMessageListenerContainer(
+    public RedisMessageListenerContainer registerShowMessageListenerContainer(
         RedisConnectionFactory connectionFactory,
         MessageListenerAdapter registerShowMessageListenerAdapter
     ) {
@@ -75,7 +75,7 @@ public class SubscriptionApiConfig {
     }
 
     @Bean
-    RedisMessageListenerContainer updateShowMessageListenerContainer(
+    public RedisMessageListenerContainer updateShowMessageListenerContainer(
         RedisConnectionFactory connectionFactory,
         MessageListenerAdapter updateShowMessageListenerAdapter
     ) {
@@ -89,7 +89,7 @@ public class SubscriptionApiConfig {
     }
 
     @Bean
-    RedisMessageListenerContainer subscriptionArtistMessageListerContainer(
+    public RedisMessageListenerContainer subscriptionArtistMessageListerContainer(
         RedisConnectionFactory connectionFactory,
         MessageListenerAdapter subscriptionArtistMessageListerAdapter
     ) {
@@ -103,7 +103,7 @@ public class SubscriptionApiConfig {
     }
 
     @Bean
-    RedisMessageListenerContainer unsubscriptionArtistMessageListerContainer(
+    public RedisMessageListenerContainer unsubscriptionArtistMessageListerContainer(
         RedisConnectionFactory connectionFactory,
         MessageListenerAdapter unsubscriptionArtistMessageListerAdapter
     ) {
@@ -117,7 +117,7 @@ public class SubscriptionApiConfig {
     }
 
     @Bean
-    RedisMessageListenerContainer subscriptionGenreMessageListerContainer(
+    public RedisMessageListenerContainer subscriptionGenreMessageListerContainer(
         RedisConnectionFactory connectionFactory,
         MessageListenerAdapter subscriptionGenreMessageListerAdapter
     ) {
@@ -131,7 +131,7 @@ public class SubscriptionApiConfig {
     }
 
     @Bean
-    RedisMessageListenerContainer unsubscriptionGenreMessageListerContainer(
+    public RedisMessageListenerContainer unsubscriptionGenreMessageListerContainer(
         RedisConnectionFactory connectionFactory,
         MessageListenerAdapter unsubscriptionGenreMessageListerAdapter
     ) {

--- a/app/api/subscription-api/src/main/java/org/example/converter/SubscriptionMessageConverter.java
+++ b/app/api/subscription-api/src/main/java/org/example/converter/SubscriptionMessageConverter.java
@@ -1,42 +1,28 @@
 package org.example.converter;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
+import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
+import org.example.conver.MessageConverter;
 import org.example.listener.dto.ArtistSubscriptionMessageApiRequest;
 import org.example.listener.dto.GenreSubscriptionMessageApiRequest;
 import org.example.listener.dto.ShowRelationSubscriptionMessageApiRequest;
 import org.springframework.data.redis.connection.Message;
 
+@UtilityClass
 @Slf4j
 public final class SubscriptionMessageConverter {
 
-    private SubscriptionMessageConverter() {
+    public ShowRelationSubscriptionMessageApiRequest toShowRelationSubscriptionMessage(
+        Message message) {
+        return MessageConverter.convertMessage(message,
+            ShowRelationSubscriptionMessageApiRequest.class);
     }
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-
-    public static ShowRelationSubscriptionMessageApiRequest toShowRelationSubscriptionMessage(Message message) {
-        return convertMessage(message, ShowRelationSubscriptionMessageApiRequest.class);
+    public ArtistSubscriptionMessageApiRequest toArtistSubscriptionMessage(Message message) {
+        return MessageConverter.convertMessage(message, ArtistSubscriptionMessageApiRequest.class);
     }
 
-    public static ArtistSubscriptionMessageApiRequest toArtistSubscriptionMessage(Message message) {
-        return convertMessage(message, ArtistSubscriptionMessageApiRequest.class);
-    }
-
-    public static GenreSubscriptionMessageApiRequest toGenreSubscriptionMessage(Message message) {
-        return convertMessage(message, GenreSubscriptionMessageApiRequest.class);
-    }
-
-    private static <T> T convertMessage(Message message, Class<T> targetType) {
-        try {
-            T convertedMessage = objectMapper.readValue(message.getBody(), targetType);
-            log.info("Message published successfully to topic: {}", new String(message.getChannel()));
-            log.info("Subscribe Message Contents ( {} : {} )", targetType.getName(), message);
-            return convertedMessage;
-        } catch (IOException e) {
-            log.error("Failed to convert message to {}", targetType.getName(), e);
-            throw new IllegalArgumentException("메시지를 받지 못했습니다.");
-        }
+    public GenreSubscriptionMessageApiRequest toGenreSubscriptionMessage(Message message) {
+        return MessageConverter.convertMessage(message, GenreSubscriptionMessageApiRequest.class);
     }
 }

--- a/app/api/subscription-api/src/main/java/org/example/service/UserSubscriptionServiceImpl.java
+++ b/app/api/subscription-api/src/main/java/org/example/service/UserSubscriptionServiceImpl.java
@@ -1,0 +1,26 @@
+package org.example.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.conver.message.UserFcmTokenMessage;
+import org.example.dto.request.UserFcmTokenDomainRequest;
+import org.example.usecase.ArtistSubscriptionUseCase;
+import org.example.usecase.GenreSubscriptionUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserSubscriptionServiceImpl implements UserSubscriptionService {
+
+    private final ArtistSubscriptionUseCase artistSubscriptionUseCase;
+    private final GenreSubscriptionUseCase genreSubscriptionUseCase;
+
+    @Override
+    @Transactional
+    public void updateUserFcmToken(UserFcmTokenMessage request) {
+        artistSubscriptionUseCase.updateUserFcmToken(
+            UserFcmTokenDomainRequest.of(request.previousFcmToken(), request.updatedFcmToken()));
+        genreSubscriptionUseCase.updateUserFcmToken(
+            UserFcmTokenDomainRequest.of(request.previousFcmToken(), request.updatedFcmToken()));
+    }
+}

--- a/app/domain/common-domain/src/main/resources/application-domain-dev.yml
+++ b/app/domain/common-domain/src/main/resources/application-domain-dev.yml
@@ -1,16 +1,14 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     show-sql: true
-    open-in-view: false
     generate-ddl: true
     defer-datasource-initialization: true
     properties:
       hibernate:
         format_sql: true
         highlight_sql: true
-        use_sql_comments: true
   datasource:
     url: ${APPLICATION_DATASOURCE_URL_DEV}
     username: ${APPLICATION_DATASOURCE_USERNAME}

--- a/app/domain/common-domain/src/main/resources/application-domain-local.yml
+++ b/app/domain/common-domain/src/main/resources/application-domain-local.yml
@@ -8,10 +8,8 @@ spring:
     hibernate:
       ddl-auto: none
     show-sql: true
-    open-in-view: false
     generate-ddl: true
     properties:
       hibernate:
         format_sql: true
         highlight_sql: true
-        use_sql_comments: true

--- a/app/domain/common-domain/src/main/resources/application-domain-prod.yml
+++ b/app/domain/common-domain/src/main/resources/application-domain-prod.yml
@@ -2,6 +2,8 @@ spring:
   jpa:
     properties:
       hibernate.jdbc.time_zone: Asia/Seoul
+      format_sql: true
+      highlight_sql: true
     hibernate:
       ddl-auto: none
     show-sql: true

--- a/app/domain/subscription-domain/src/main/java/org/example/dto/request/UserFcmTokenDomainRequest.java
+++ b/app/domain/subscription-domain/src/main/java/org/example/dto/request/UserFcmTokenDomainRequest.java
@@ -1,0 +1,10 @@
+package org.example.dto.request;
+
+public record UserFcmTokenDomainRequest(
+    String previousFcmToken,
+    String updatedFcmToken
+) {
+    public static UserFcmTokenDomainRequest of(String previousFcmToken, String updatedFcmToken) {
+        return new UserFcmTokenDomainRequest(previousFcmToken, updatedFcmToken);
+    }
+}

--- a/app/domain/subscription-domain/src/main/java/org/example/entity/ArtistSubscription.java
+++ b/app/domain/subscription-domain/src/main/java/org/example/entity/ArtistSubscription.java
@@ -38,4 +38,8 @@ public class ArtistSubscription extends BaseEntity {
     public void unsubscribe() {
         this.softDelete();
     }
+
+    public void updateUserFcmToken(String fcmToken) {
+        this.userFcmToken = fcmToken;
+    }
 }

--- a/app/domain/subscription-domain/src/main/java/org/example/entity/GenreSubscription.java
+++ b/app/domain/subscription-domain/src/main/java/org/example/entity/GenreSubscription.java
@@ -38,4 +38,8 @@ public class GenreSubscription extends BaseEntity {
     public void unsubscribe() {
         this.softDelete();
     }
+
+    public void updateUserFcmToken(String fcmToken) {
+        this.userFcmToken = fcmToken;
+    }
 }

--- a/app/domain/subscription-domain/src/main/java/org/example/usecase/ArtistSubscriptionUseCase.java
+++ b/app/domain/subscription-domain/src/main/java/org/example/usecase/ArtistSubscriptionUseCase.java
@@ -55,7 +55,7 @@ public class ArtistSubscriptionUseCase {
     public void artistUnsubscribe(ArtistSubscriptionMessageDomainRequest request) {
         var artistIds = request.artists().stream()
             .map(ArtistMessageDomainRequest::artistId)
-            .toList();
+            .collect(Collectors.toSet());
 
         var artistSubscriptions = artistSubscriptionRepository.findSubscriptionList(
             request.userFcmToken());

--- a/app/domain/subscription-domain/src/main/java/org/example/usecase/ArtistSubscriptionUseCase.java
+++ b/app/domain/subscription-domain/src/main/java/org/example/usecase/ArtistSubscriptionUseCase.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.example.dto.request.ArtistMessageDomainRequest;
 import org.example.dto.request.ArtistSubscriptionMessageDomainRequest;
+import org.example.dto.request.UserFcmTokenDomainRequest;
 import org.example.dto.response.ArtistSubscriptionDomainResponse;
 import org.example.entity.ArtistSubscription;
 import org.example.repository.subscription.artistsubscription.ArtistSubscriptionRepository;
@@ -19,14 +20,16 @@ public class ArtistSubscriptionUseCase {
 
     private final ArtistSubscriptionRepository artistSubscriptionRepository;
 
-    public List<ArtistSubscriptionDomainResponse> findArtistSubscriptionsByArtistIds(List<UUID> artistIds) {
+    public List<ArtistSubscriptionDomainResponse> findArtistSubscriptionsByArtistIds(
+        List<UUID> artistIds) {
         return artistSubscriptionRepository.findArtistSubscriptionsByArtistIds(artistIds);
     }
 
     @Transactional
     public void artistSubscribe(ArtistSubscriptionMessageDomainRequest request) {
         var newSubscriptions = new ArrayList<ArtistSubscription>();
-        var allSubscriptionByArtistId = artistSubscriptionRepository.findAllByUserFcmToken(request.userFcmToken())
+        var allSubscriptionByArtistId = artistSubscriptionRepository.findAllByUserFcmToken(
+                request.userFcmToken())
             .stream()
             .collect(Collectors.toMap(ArtistSubscription::getArtistId, it -> it));
 
@@ -54,11 +57,22 @@ public class ArtistSubscriptionUseCase {
             .map(ArtistMessageDomainRequest::artistId)
             .toList();
 
-        var artistSubscriptions = artistSubscriptionRepository.findSubscriptionList(request.userFcmToken());
+        var artistSubscriptions = artistSubscriptionRepository.findSubscriptionList(
+            request.userFcmToken());
         var filteredSubscription = artistSubscriptions.stream()
             .filter(it -> artistIds.contains(it.getArtistId()))
             .toList();
 
         filteredSubscription.forEach(ArtistSubscription::unsubscribe);
+    }
+
+    public void updateUserFcmToken(UserFcmTokenDomainRequest request) {
+        List<ArtistSubscription> artistSubscriptions = artistSubscriptionRepository.findAllByUserFcmToken(
+            request.previousFcmToken());
+
+        artistSubscriptions.forEach(artistSubscription -> {
+            artistSubscription.updateUserFcmToken(request.updatedFcmToken());
+            artistSubscriptionRepository.save(artistSubscription);
+        });
     }
 }

--- a/app/domain/subscription-domain/src/main/java/org/example/usecase/GenreSubscriptionUseCase.java
+++ b/app/domain/subscription-domain/src/main/java/org/example/usecase/GenreSubscriptionUseCase.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.example.dto.request.GenreMessageDomainRequest;
 import org.example.dto.request.GenreSubscriptionMessageDomainRequest;
+import org.example.dto.request.UserFcmTokenDomainRequest;
 import org.example.dto.response.GenreSubscriptionDomainResponse;
 import org.example.entity.GenreSubscription;
 import org.example.repository.subscription.genresubscription.GenreSubscriptionRepository;
@@ -19,7 +20,8 @@ public class GenreSubscriptionUseCase {
 
     private final GenreSubscriptionRepository genreSubscriptionRepository;
 
-    public List<GenreSubscriptionDomainResponse> findGenreSubscriptionsByGenreIds(List<UUID> genreIds) {
+    public List<GenreSubscriptionDomainResponse> findGenreSubscriptionsByGenreIds(
+        List<UUID> genreIds) {
         return genreSubscriptionRepository.findGenreSubscriptionsByGenreIds(genreIds);
     }
 
@@ -55,11 +57,22 @@ public class GenreSubscriptionUseCase {
             .map(GenreMessageDomainRequest::genreId)
             .toList();
 
-        var artistSubscriptions = genreSubscriptionRepository.findSubscriptionList(request.userFcmToken());
+        var artistSubscriptions = genreSubscriptionRepository.findSubscriptionList(
+            request.userFcmToken());
         var filteredSubscription = artistSubscriptions.stream()
             .filter(it -> genreIds.contains(it.getGenreId()))
             .toList();
 
         filteredSubscription.forEach(GenreSubscription::unsubscribe);
+    }
+
+    public void updateUserFcmToken(UserFcmTokenDomainRequest request) {
+        List<GenreSubscription> genreSubscriptions = genreSubscriptionRepository.findAllByUserFcmToken(
+            request.previousFcmToken());
+
+        genreSubscriptions.forEach(genreSubscription -> {
+            genreSubscription.updateUserFcmToken(request.updatedFcmToken());
+            genreSubscriptionRepository.save(genreSubscription);
+        });
     }
 }

--- a/app/domain/subscription-domain/src/main/java/org/example/usecase/GenreSubscriptionUseCase.java
+++ b/app/domain/subscription-domain/src/main/java/org/example/usecase/GenreSubscriptionUseCase.java
@@ -55,7 +55,7 @@ public class GenreSubscriptionUseCase {
     public void genreUnsubscribe(GenreSubscriptionMessageDomainRequest request) {
         var genreIds = request.genres().stream()
             .map(GenreMessageDomainRequest::genreId)
-            .toList();
+            .collect(Collectors.toSet());
 
         var artistSubscriptions = genreSubscriptionRepository.findSubscriptionList(
             request.userFcmToken());


### PR DESCRIPTION
## 😋 작업한 내용

- 사용자의 FCM 토큰이 변경시 아티스트 구독 목록과 장르 구독 목록의 FCM 토큰을 업데이트 해줍니다. 

## 🙏 PR Point

- 내부 흐름 구조

## 👍 관련 이슈

- Resolved : #16 


---