### PR TITLE
Feat/ticketing alert userId

### DIFF
--- a/app/api/common-api/src/main/java/org/example/listener/UpdateUserFcmTokenListener.java
+++ b/app/api/common-api/src/main/java/org/example/listener/UpdateUserFcmTokenListener.java
@@ -1,6 +1,7 @@
-package org.example.listner;
+package org.example.listener;
 
 import lombok.RequiredArgsConstructor;
+
 import org.example.conver.UserMessageConverter;
 import org.example.metric.MessageQueueSubMonitored;
 import org.example.service.UserSubscriptionService;

--- a/app/api/common-api/src/main/java/org/example/listener/UpdateUserFcmTokenListener.java
+++ b/app/api/common-api/src/main/java/org/example/listener/UpdateUserFcmTokenListener.java
@@ -1,7 +1,6 @@
 package org.example.listener;
 
 import lombok.RequiredArgsConstructor;
-
 import org.example.conver.UserMessageConverter;
 import org.example.metric.MessageQueueSubMonitored;
 import org.example.service.UserSubscriptionService;

--- a/app/api/ticketing-api/src/main/java/org/example/listener/dto/TicketingReservationMessageApiRequest.java
+++ b/app/api/ticketing-api/src/main/java/org/example/listener/dto/TicketingReservationMessageApiRequest.java
@@ -1,10 +1,9 @@
 package org.example.listener.dto;
 
-import org.example.service.dto.request.TicketingReservationMessageServiceRequest;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+import org.example.service.dto.request.TicketingReservationMessageServiceRequest;
 
 public record TicketingReservationMessageApiRequest(
         UUID userId,

--- a/app/api/ticketing-api/src/main/java/org/example/listener/dto/TicketingReservationMessageApiRequest.java
+++ b/app/api/ticketing-api/src/main/java/org/example/listener/dto/TicketingReservationMessageApiRequest.java
@@ -6,22 +6,21 @@ import java.util.UUID;
 import org.example.service.dto.request.TicketingReservationMessageServiceRequest;
 
 public record TicketingReservationMessageApiRequest(
-    String userFcmToken,
-    String name,
-    UUID showId,
-    String ticketingAt,
-    List<String> addAlertAts,
-    List<String> deleteAlertAts
-) {
+        UUID userId,
+        String name,
+        UUID showId,
+        String ticketingAt,
+        List<String> addAlertAts,
+        List<String> deleteAlertAts) {
 
     public TicketingReservationMessageServiceRequest toServiceRequest() {
         return TicketingReservationMessageServiceRequest.builder()
-            .userFcmToken(userFcmToken)
-            .name(name)
-            .showId(showId)
-            .ticketingAt(LocalDateTime.parse(ticketingAt))
-            .addAlertAts(addAlertAts.stream().map(LocalDateTime::parse).toList())
-            .deleteAlertAts(deleteAlertAts.stream().map(LocalDateTime::parse).toList())
-            .build();
+                .userId(userId)
+                .name(name)
+                .showId(showId)
+                .ticketingAt(LocalDateTime.parse(ticketingAt))
+                .addAlertAts(addAlertAts.stream().map(LocalDateTime::parse).toList())
+                .deleteAlertAts(deleteAlertAts.stream().map(LocalDateTime::parse).toList())
+                .build();
     }
 }

--- a/app/api/ticketing-api/src/main/java/org/example/listener/dto/TicketingReservationMessageApiRequest.java
+++ b/app/api/ticketing-api/src/main/java/org/example/listener/dto/TicketingReservationMessageApiRequest.java
@@ -1,9 +1,10 @@
 package org.example.listener.dto;
 
+import org.example.service.dto.request.TicketingReservationMessageServiceRequest;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
-import org.example.service.dto.request.TicketingReservationMessageServiceRequest;
 
 public record TicketingReservationMessageApiRequest(
         UUID userId,
@@ -15,12 +16,12 @@ public record TicketingReservationMessageApiRequest(
 
     public TicketingReservationMessageServiceRequest toServiceRequest() {
         return TicketingReservationMessageServiceRequest.builder()
-                .userId(userId)
-                .name(name)
-                .showId(showId)
-                .ticketingAt(LocalDateTime.parse(ticketingAt))
-                .addAlertAts(addAlertAts.stream().map(LocalDateTime::parse).toList())
-                .deleteAlertAts(deleteAlertAts.stream().map(LocalDateTime::parse).toList())
-                .build();
+            .userId(userId)
+            .name(name)
+            .showId(showId)
+            .ticketingAt(LocalDateTime.parse(ticketingAt))
+            .addAlertAts(addAlertAts.stream().map(LocalDateTime::parse).toList())
+            .deleteAlertAts(deleteAlertAts.stream().map(LocalDateTime::parse).toList())
+            .build();
     }
 }

--- a/app/api/ticketing-api/src/main/java/org/example/service/dto/request/TicketingReservationMessageServiceRequest.java
+++ b/app/api/ticketing-api/src/main/java/org/example/service/dto/request/TicketingReservationMessageServiceRequest.java
@@ -17,12 +17,12 @@ public record TicketingReservationMessageServiceRequest(
 
     public TicketingReservationMessageDomainRequest toDomainRequest() {
         return TicketingReservationMessageDomainRequest.builder()
-                .userId(userId)
-                .name(name)
-                .showId(showId)
-                .ticketingAt(ticketingAt)
-                .addAlertAts(addAlertAts)
-                .deleteAlertAts(deleteAlertAts)
-                .build();
+            .userId(userId)
+            .name(name)
+            .showId(showId)
+            .ticketingAt(ticketingAt)
+            .addAlertAts(addAlertAts)
+            .deleteAlertAts(deleteAlertAts)
+            .build();
     }
 }

--- a/app/api/ticketing-api/src/main/java/org/example/service/dto/request/TicketingReservationMessageServiceRequest.java
+++ b/app/api/ticketing-api/src/main/java/org/example/service/dto/request/TicketingReservationMessageServiceRequest.java
@@ -8,22 +8,21 @@ import org.example.dto.request.TicketingReservationMessageDomainRequest;
 
 @Builder
 public record TicketingReservationMessageServiceRequest(
-    String userFcmToken,
-    String name,
-    UUID showId,
-    LocalDateTime ticketingAt,
-    List<LocalDateTime> addAlertAts,
-    List<LocalDateTime> deleteAlertAts
-) {
+        UUID userId,
+        String name,
+        UUID showId,
+        LocalDateTime ticketingAt,
+        List<LocalDateTime> addAlertAts,
+        List<LocalDateTime> deleteAlertAts) {
 
     public TicketingReservationMessageDomainRequest toDomainRequest() {
         return TicketingReservationMessageDomainRequest.builder()
-            .userFcmToken(userFcmToken)
-            .name(name)
-            .showId(showId)
-            .ticketingAt(ticketingAt)
-            .addAlertAts(addAlertAts)
-            .deleteAlertAts(deleteAlertAts)
-            .build();
+                .userId(userId)
+                .name(name)
+                .showId(showId)
+                .ticketingAt(ticketingAt)
+                .addAlertAts(addAlertAts)
+                .deleteAlertAts(deleteAlertAts)
+                .build();
     }
 }

--- a/app/api/ticketing-api/src/main/java/org/example/service/dto/response/TicketingAlertServiceRequest.java
+++ b/app/api/ticketing-api/src/main/java/org/example/service/dto/response/TicketingAlertServiceRequest.java
@@ -8,24 +8,22 @@ import org.example.dto.response.TicketingAlertToSchedulerDomainResponse;
 
 @Builder
 public record TicketingAlertServiceRequest(
-    String name,
-    String userFcmToken,
-    UUID showId,
-    LocalDateTime ticketingAt,
-    List<LocalDateTime> addAlertAts,
-    List<LocalDateTime> deleteAlertAts
-) {
+        String name,
+        UUID userId,
+        UUID showId,
+        LocalDateTime ticketingAt,
+        List<LocalDateTime> addAlertAts,
+        List<LocalDateTime> deleteAlertAts) {
 
     public static TicketingAlertServiceRequest from(
-        TicketingAlertToSchedulerDomainResponse ticketingAlert
-    ) {
+            TicketingAlertToSchedulerDomainResponse ticketingAlert) {
         return TicketingAlertServiceRequest.builder()
-            .name(ticketingAlert.name())
-            .userFcmToken(ticketingAlert.userFcmToken())
-            .showId(ticketingAlert.showId())
-            .ticketingAt(ticketingAlert.ticketingAt())
-            .addAlertAts(ticketingAlert.addAlertAts())
-            .deleteAlertAts(ticketingAlert.deleteAlertAts())
-            .build();
+                .name(ticketingAlert.name())
+                .userId(ticketingAlert.userId())
+                .showId(ticketingAlert.showId())
+                .ticketingAt(ticketingAlert.ticketingAt())
+                .addAlertAts(ticketingAlert.addAlertAts())
+                .deleteAlertAts(ticketingAlert.deleteAlertAts())
+                .build();
     }
 }

--- a/app/api/ticketing-api/src/main/java/org/example/service/dto/response/TicketingAlertServiceRequest.java
+++ b/app/api/ticketing-api/src/main/java/org/example/service/dto/response/TicketingAlertServiceRequest.java
@@ -18,12 +18,12 @@ public record TicketingAlertServiceRequest(
     public static TicketingAlertServiceRequest from(
             TicketingAlertToSchedulerDomainResponse ticketingAlert) {
         return TicketingAlertServiceRequest.builder()
-                .name(ticketingAlert.name())
-                .userId(ticketingAlert.userId())
-                .showId(ticketingAlert.showId())
-                .ticketingAt(ticketingAlert.ticketingAt())
-                .addAlertAts(ticketingAlert.addAlertAts())
-                .deleteAlertAts(ticketingAlert.deleteAlertAts())
-                .build();
+            .name(ticketingAlert.name())
+            .userId(ticketingAlert.userId())
+            .showId(ticketingAlert.showId())
+            .ticketingAt(ticketingAlert.ticketingAt())
+            .addAlertAts(ticketingAlert.addAlertAts())
+            .deleteAlertAts(ticketingAlert.deleteAlertAts())
+            .build();
     }
 }

--- a/app/batch/src/main/java/org/example/component/TicketingAlertBatchComponent.java
+++ b/app/batch/src/main/java/org/example/component/TicketingAlertBatchComponent.java
@@ -1,12 +1,9 @@
 package org.example.component;
 
 import jakarta.annotation.PostConstruct;
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.Date;
-import java.util.List;
+
 import lombok.RequiredArgsConstructor;
+
 import org.example.batch.TicketingAlertBatch;
 import org.example.dto.response.TicketingAlertToSchedulerDomainResponse;
 import org.example.job.TicketingAlertQuartzJob;
@@ -22,6 +19,12 @@ import org.quartz.Trigger;
 import org.quartz.TriggerBuilder;
 import org.quartz.TriggerKey;
 import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -43,12 +46,8 @@ public class TicketingAlertBatchComponent implements TicketingAlertBatch {
     public void reserveTicketingAlerts(TicketingAlertServiceRequest ticketingAlert) {
         try {
             JobKey jobKey = getJobKey(ticketingAlert);
-            boolean jobExists = ticketingAlertScheduler.checkExists(jobKey);
-
-            if (!jobExists) {
-                JobDetail jobDetail = getJobDetail(ticketingAlert);
-                ticketingAlertScheduler.addJob(jobDetail, true, true);
-            }
+            JobDetail jobDetail = getJobDetail(ticketingAlert);
+            ticketingAlertScheduler.addJob(jobDetail, true, true);
 
             List<TriggerKey> triggerKeysToRemove = ticketingAlert.deleteAlertAts().stream()
                 .map(alertTime -> getTriggerKey(ticketingAlert, alertTime))
@@ -74,7 +73,7 @@ public class TicketingAlertBatchComponent implements TicketingAlertBatch {
         LocalDateTime alertTime
     ) {
         return TriggerKey.triggerKey(
-            ticketingAlert.userFcmToken() + " : "
+            ticketingAlert.userId() + " : "
                 + ticketingAlert.showId() + " : "
                 + alertTime,
             calculateAlertMinutes(alertTime, ticketingAlert.ticketingAt())
@@ -89,7 +88,7 @@ public class TicketingAlertBatchComponent implements TicketingAlertBatch {
         JobKey jobKey = getJobKey(ticketingAlert);
 
         JobDataMap jobDataMap = new JobDataMap();
-        jobDataMap.put("userFcmToken", ticketingAlert.userFcmToken());
+        jobDataMap.put("userFcmToken", ticketingAlert.userId());
         jobDataMap.put("name", ticketingAlert.name());
         jobDataMap.put("showId", ticketingAlert.showId().toString());
         jobDataMap.put("retryCount", 0);
@@ -102,7 +101,7 @@ public class TicketingAlertBatchComponent implements TicketingAlertBatch {
 
     private JobKey getJobKey(TicketingAlertServiceRequest ticketingAlert) {
         return new JobKey(
-            ticketingAlert.userFcmToken() + " : "
+            ticketingAlert.userId() + " : "
                 + ticketingAlert.showId()
         );
     }

--- a/app/batch/src/main/java/org/example/component/TicketingAlertBatchComponent.java
+++ b/app/batch/src/main/java/org/example/component/TicketingAlertBatchComponent.java
@@ -1,9 +1,12 @@
 package org.example.component;
 
 import jakarta.annotation.PostConstruct;
-
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-
 import org.example.batch.TicketingAlertBatch;
 import org.example.dto.response.TicketingAlertToSchedulerDomainResponse;
 import org.example.job.TicketingAlertQuartzJob;
@@ -19,12 +22,6 @@ import org.quartz.Trigger;
 import org.quartz.TriggerBuilder;
 import org.quartz.TriggerKey;
 import org.springframework.stereotype.Component;
-
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.Date;
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor

--- a/app/domain/ticketing-domain/src/main/java/org/example/dto/request/TicketingAlertTargetDomainResponse.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/dto/request/TicketingAlertTargetDomainResponse.java
@@ -1,24 +1,21 @@
 package org.example.dto.request;
 
+import lombok.Builder;
+
+import org.example.entity.TicketingAlert;
+
 import java.time.LocalDateTime;
 import java.util.UUID;
-import lombok.Builder;
-import org.example.entity.TicketingAlert;
 
 @Builder
 public record TicketingAlertTargetDomainResponse(
-    String userFcmToken,
-    UUID showId,
-    String name,
-    LocalDateTime ticketingAt
-) {
+        UUID userId, UUID showId, String name, LocalDateTime ticketingAt) {
     public static TicketingAlertTargetDomainResponse from(TicketingAlert ticketingAlert) {
         return TicketingAlertTargetDomainResponse.builder()
-            .userFcmToken(ticketingAlert.getUserFcmToken())
-            .showId(ticketingAlert.getShowId())
-            .name(ticketingAlert.getName())
-            .ticketingAt(ticketingAlert.getTicketingTime())
-            .build();
+                .userId(ticketingAlert.getUserId())
+                .showId(ticketingAlert.getShowId())
+                .name(ticketingAlert.getName())
+                .ticketingAt(ticketingAlert.getTicketingTime())
+                .build();
     }
-
 }

--- a/app/domain/ticketing-domain/src/main/java/org/example/dto/request/TicketingAlertTargetDomainResponse.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/dto/request/TicketingAlertTargetDomainResponse.java
@@ -1,11 +1,9 @@
 package org.example.dto.request;
 
-import lombok.Builder;
-
-import org.example.entity.TicketingAlert;
-
 import java.time.LocalDateTime;
 import java.util.UUID;
+import lombok.Builder;
+import org.example.entity.TicketingAlert;
 
 @Builder
 public record TicketingAlertTargetDomainResponse(

--- a/app/domain/ticketing-domain/src/main/java/org/example/dto/request/TicketingAlertTargetDomainResponse.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/dto/request/TicketingAlertTargetDomainResponse.java
@@ -12,10 +12,10 @@ public record TicketingAlertTargetDomainResponse(
         UUID userId, UUID showId, String name, LocalDateTime ticketingAt) {
     public static TicketingAlertTargetDomainResponse from(TicketingAlert ticketingAlert) {
         return TicketingAlertTargetDomainResponse.builder()
-                .userId(ticketingAlert.getUserId())
-                .showId(ticketingAlert.getShowId())
-                .name(ticketingAlert.getName())
-                .ticketingAt(ticketingAlert.getTicketingTime())
-                .build();
+            .userId(ticketingAlert.getUserId())
+            .showId(ticketingAlert.getShowId())
+            .name(ticketingAlert.getName())
+            .ticketingAt(ticketingAlert.getTicketingTime())
+            .build();
     }
 }

--- a/app/domain/ticketing-domain/src/main/java/org/example/dto/request/TicketingReservationMessageDomainRequest.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/dto/request/TicketingReservationMessageDomainRequest.java
@@ -12,4 +12,6 @@ public record TicketingReservationMessageDomainRequest(
         UUID showId,
         LocalDateTime ticketingAt,
         List<LocalDateTime> addAlertAts,
-        List<LocalDateTime> deleteAlertAts) {}
+        List<LocalDateTime> deleteAlertAts
+) {
+}

--- a/app/domain/ticketing-domain/src/main/java/org/example/dto/request/TicketingReservationMessageDomainRequest.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/dto/request/TicketingReservationMessageDomainRequest.java
@@ -7,11 +7,11 @@ import lombok.Builder;
 
 @Builder
 public record TicketingReservationMessageDomainRequest(
-        UUID userId,
-        String name,
-        UUID showId,
-        LocalDateTime ticketingAt,
-        List<LocalDateTime> addAlertAts,
-        List<LocalDateTime> deleteAlertAts
+    UUID userId,
+    String name,
+    UUID showId,
+    LocalDateTime ticketingAt,
+    List<LocalDateTime> addAlertAts,
+    List<LocalDateTime> deleteAlertAts
 ) {
 }

--- a/app/domain/ticketing-domain/src/main/java/org/example/dto/request/TicketingReservationMessageDomainRequest.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/dto/request/TicketingReservationMessageDomainRequest.java
@@ -7,12 +7,9 @@ import lombok.Builder;
 
 @Builder
 public record TicketingReservationMessageDomainRequest(
-    String userFcmToken,
-    String name,
-    UUID showId,
-    LocalDateTime ticketingAt,
-    List<LocalDateTime> addAlertAts,
-    List<LocalDateTime> deleteAlertAts
-) {
-
-}
+        UUID userId,
+        String name,
+        UUID showId,
+        LocalDateTime ticketingAt,
+        List<LocalDateTime> addAlertAts,
+        List<LocalDateTime> deleteAlertAts) {}

--- a/app/domain/ticketing-domain/src/main/java/org/example/dto/response/TicketingAlertToSchedulerDomainResponse.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/dto/response/TicketingAlertToSchedulerDomainResponse.java
@@ -1,49 +1,46 @@
 package org.example.dto.response;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
 import lombok.Builder;
+
 import org.example.dto.request.TicketingAlertTargetDomainResponse;
 import org.example.dto.request.TicketingReservationMessageDomainRequest;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
 @Builder
 public record TicketingAlertToSchedulerDomainResponse(
-    String name,
-    String userFcmToken,
-    UUID showId,
-    LocalDateTime ticketingAt,
-    List<LocalDateTime> addAlertAts,
-    List<LocalDateTime> deleteAlertAts
-) {
+        String name,
+        UUID userId,
+        UUID showId,
+        LocalDateTime ticketingAt,
+        List<LocalDateTime> addAlertAts,
+        List<LocalDateTime> deleteAlertAts) {
 
     public static TicketingAlertToSchedulerDomainResponse as(
-        TicketingReservationMessageDomainRequest request,
-        List<LocalDateTime> addAlertAts,
-        List<LocalDateTime> deleteAlertAts
-    ) {
+            TicketingReservationMessageDomainRequest request,
+            List<LocalDateTime> addAlertAts,
+            List<LocalDateTime> deleteAlertAts) {
         return TicketingAlertToSchedulerDomainResponse.builder()
-            .name(request.name())
-            .userFcmToken(request.userFcmToken())
-            .showId(request.showId())
-            .ticketingAt(request.ticketingAt())
-            .addAlertAts(addAlertAts)
-            .deleteAlertAts(deleteAlertAts)
-            .build();
+                .name(request.name())
+                .userId(request.userId())
+                .showId(request.showId())
+                .ticketingAt(request.ticketingAt())
+                .addAlertAts(addAlertAts)
+                .deleteAlertAts(deleteAlertAts)
+                .build();
     }
 
-
     public static TicketingAlertToSchedulerDomainResponse as(
-        TicketingAlertTargetDomainResponse key,
-        List<LocalDateTime> value
-    ) {
+            TicketingAlertTargetDomainResponse key, List<LocalDateTime> value) {
         return TicketingAlertToSchedulerDomainResponse.builder()
-            .name(key.name())
-            .userFcmToken(key.userFcmToken())
-            .showId(key.showId())
-            .ticketingAt(key.ticketingAt())
-            .addAlertAts(value)
-            .deleteAlertAts(List.of())
-            .build();
+                .name(key.name())
+                .userId(key.userId())
+                .showId(key.showId())
+                .ticketingAt(key.ticketingAt())
+                .addAlertAts(value)
+                .deleteAlertAts(List.of())
+                .build();
     }
 }

--- a/app/domain/ticketing-domain/src/main/java/org/example/dto/response/TicketingAlertToSchedulerDomainResponse.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/dto/response/TicketingAlertToSchedulerDomainResponse.java
@@ -23,24 +23,24 @@ public record TicketingAlertToSchedulerDomainResponse(
             List<LocalDateTime> addAlertAts,
             List<LocalDateTime> deleteAlertAts) {
         return TicketingAlertToSchedulerDomainResponse.builder()
-                .name(request.name())
-                .userId(request.userId())
-                .showId(request.showId())
-                .ticketingAt(request.ticketingAt())
-                .addAlertAts(addAlertAts)
-                .deleteAlertAts(deleteAlertAts)
-                .build();
+            .name(request.name())
+            .userId(request.userId())
+            .showId(request.showId())
+            .ticketingAt(request.ticketingAt())
+            .addAlertAts(addAlertAts)
+            .deleteAlertAts(deleteAlertAts)
+            .build();
     }
 
     public static TicketingAlertToSchedulerDomainResponse as(
             TicketingAlertTargetDomainResponse key, List<LocalDateTime> value) {
         return TicketingAlertToSchedulerDomainResponse.builder()
-                .name(key.name())
-                .userId(key.userId())
-                .showId(key.showId())
-                .ticketingAt(key.ticketingAt())
-                .addAlertAts(value)
-                .deleteAlertAts(List.of())
-                .build();
+            .name(key.name())
+            .userId(key.userId())
+            .showId(key.showId())
+            .ticketingAt(key.ticketingAt())
+            .addAlertAts(value)
+            .deleteAlertAts(List.of())
+            .build();
     }
 }

--- a/app/domain/ticketing-domain/src/main/java/org/example/dto/response/TicketingAlertToSchedulerDomainResponse.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/dto/response/TicketingAlertToSchedulerDomainResponse.java
@@ -1,13 +1,11 @@
 package org.example.dto.response;
 
-import lombok.Builder;
-
-import org.example.dto.request.TicketingAlertTargetDomainResponse;
-import org.example.dto.request.TicketingReservationMessageDomainRequest;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+import lombok.Builder;
+import org.example.dto.request.TicketingAlertTargetDomainResponse;
+import org.example.dto.request.TicketingReservationMessageDomainRequest;
 
 @Builder
 public record TicketingAlertToSchedulerDomainResponse(

--- a/app/domain/ticketing-domain/src/main/java/org/example/entity/TicketingAlert.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/entity/TicketingAlert.java
@@ -3,14 +3,12 @@ package org.example.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
-
+import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Entity
 @Getter

--- a/app/domain/ticketing-domain/src/main/java/org/example/entity/TicketingAlert.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/entity/TicketingAlert.java
@@ -3,12 +3,14 @@ package org.example.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
-import java.util.UUID;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -22,8 +24,8 @@ public class TicketingAlert extends BaseEntity {
     @Column(name = "schedule_alert_time", nullable = false)
     private LocalDateTime alertTime;
 
-    @Column(name = "user_fcm_token", nullable = false)
-    private String userFcmToken;
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
 
     @Column(name = "show_id", nullable = false)
     private UUID showId;
@@ -33,15 +35,14 @@ public class TicketingAlert extends BaseEntity {
 
     @Builder
     private TicketingAlert(
-        String name,
-        LocalDateTime alertTime,
-        String userFcmToken,
-        UUID showId,
-        LocalDateTime ticketingTime
-    ) {
+            String name,
+            LocalDateTime alertTime,
+            UUID userId,
+            UUID showId,
+            LocalDateTime ticketingTime) {
         this.name = name;
         this.alertTime = alertTime;
-        this.userFcmToken = userFcmToken;
+        this.userId = userId;
         this.showId = showId;
         this.ticketingTime = ticketingTime;
     }

--- a/app/domain/ticketing-domain/src/main/java/org/example/entity/TicketingAlert.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/entity/TicketingAlert.java
@@ -35,11 +35,12 @@ public class TicketingAlert extends BaseEntity {
 
     @Builder
     private TicketingAlert(
-            String name,
-            LocalDateTime alertTime,
-            UUID userId,
-            UUID showId,
-            LocalDateTime ticketingTime) {
+        String name,
+        LocalDateTime alertTime,
+        UUID userId,
+        UUID showId,
+        LocalDateTime ticketingTime
+    ) {
         this.name = name;
         this.alertTime = alertTime;
         this.userId = userId;

--- a/app/domain/ticketing-domain/src/main/java/org/example/repository/ticketingalert/TicketingAlertRepository.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/repository/ticketingalert/TicketingAlertRepository.java
@@ -1,11 +1,10 @@
 package org.example.repository.ticketingalert;
 
-import org.example.entity.TicketingAlert;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+import org.example.entity.TicketingAlert;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TicketingAlertRepository extends JpaRepository<TicketingAlert, UUID> {
 

--- a/app/domain/ticketing-domain/src/main/java/org/example/repository/ticketingalert/TicketingAlertRepository.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/repository/ticketingalert/TicketingAlertRepository.java
@@ -1,17 +1,15 @@
 package org.example.repository.ticketingalert;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
 import org.example.entity.TicketingAlert;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
 public interface TicketingAlertRepository extends JpaRepository<TicketingAlert, UUID> {
 
-    List<TicketingAlert> findAllByUserFcmTokenAndShowIdAndIsDeletedFalse(
-        String userFcmToken,
-        UUID showId
-    );
+    List<TicketingAlert> findAllByUserIdAndShowIdAndIsDeletedFalse(UUID userId, UUID showId);
 
     List<TicketingAlert> findAllByIsDeletedFalseAndAlertTimeAfter(LocalDateTime alertTime);
 }

--- a/app/domain/ticketing-domain/src/main/java/org/example/usecase/TicketingAlertUseCase.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/usecase/TicketingAlertUseCase.java
@@ -1,7 +1,10 @@
 package org.example.usecase;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-
 import org.example.dto.request.TicketingAlertTargetDomainResponse;
 import org.example.dto.request.TicketingReservationMessageDomainRequest;
 import org.example.dto.response.TicketingAlertToSchedulerDomainResponse;
@@ -10,11 +13,6 @@ import org.example.entity.TicketingAlert;
 import org.example.repository.ticketingalert.TicketingAlertRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor

--- a/app/domain/ticketing-domain/src/main/java/org/example/usecase/TicketingAlertUseCase.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/usecase/TicketingAlertUseCase.java
@@ -1,10 +1,7 @@
 package org.example.usecase;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+
 import org.example.dto.request.TicketingAlertTargetDomainResponse;
 import org.example.dto.request.TicketingReservationMessageDomainRequest;
 import org.example.dto.response.TicketingAlertToSchedulerDomainResponse;
@@ -14,6 +11,11 @@ import org.example.repository.ticketingalert.TicketingAlertRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @Component
 @RequiredArgsConstructor
 public class TicketingAlertUseCase {
@@ -22,65 +24,66 @@ public class TicketingAlertUseCase {
 
     public List<TicketingAlertToSchedulerDomainResponse> findAllTicketingAlerts() {
         Map<TicketingAlertTargetDomainResponse, List<LocalDateTime>> groupedAlerts =
-            ticketingAlertRepository.findAllByIsDeletedFalseAndAlertTimeAfter(LocalDateTime.now())
-                .stream()
-                .collect(Collectors.groupingBy(
-                    TicketingAlertTargetDomainResponse::from,
-                    Collectors.mapping(
-                        TicketingAlert::getAlertTime,
-                        Collectors.toList()
-                    )
-                ));
+                ticketingAlertRepository
+                        .findAllByIsDeletedFalseAndAlertTimeAfter(LocalDateTime.now())
+                        .stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        TicketingAlertTargetDomainResponse::from,
+                                        Collectors.mapping(
+                                                TicketingAlert::getAlertTime,
+                                                Collectors.toList())));
 
         return groupedAlerts.entrySet().stream()
-            .map(entry -> TicketingAlertToSchedulerDomainResponse.as(
-                    entry.getKey(),
-                    entry.getValue()
-                )
-            )
-            .toList();
+                .map(
+                        entry ->
+                                TicketingAlertToSchedulerDomainResponse.as(
+                                        entry.getKey(), entry.getValue()))
+                .toList();
     }
 
     @Transactional
     public TicketingAlertToSchedulerDomainResponse reserveTicketingAlert(
-        TicketingReservationMessageDomainRequest ticketingReservations
-    ) {
+            TicketingReservationMessageDomainRequest ticketingReservations) {
         return TicketingAlertToSchedulerDomainResponse.as(
-            ticketingReservations,
-            addAlerts(ticketingReservations),
-            removeAlerts(ticketingReservations)
-        );
+                ticketingReservations,
+                addAlerts(ticketingReservations),
+                removeAlerts(ticketingReservations));
     }
 
     private List<LocalDateTime> addAlerts(
-        TicketingReservationMessageDomainRequest ticketingReservations
-    ) {
-        List<TicketingAlert> alertsToAdd = ticketingReservations.addAlertAts().stream()
-            .map(addAt -> TicketingAlert.builder()
-                .name(ticketingReservations.name())
-                .alertTime(addAt)
-                .userFcmToken(ticketingReservations.userFcmToken())
-                .showId(ticketingReservations.showId())
-                .ticketingTime(ticketingReservations.ticketingAt())
-                .build()
-            )
-            .toList();
+            TicketingReservationMessageDomainRequest ticketingReservations) {
+        List<TicketingAlert> alertsToAdd =
+                ticketingReservations.addAlertAts().stream()
+                        .map(
+                                addAt ->
+                                        TicketingAlert.builder()
+                                                .name(ticketingReservations.name())
+                                                .alertTime(addAt)
+                                                .userId(ticketingReservations.userId())
+                                                .showId(ticketingReservations.showId())
+                                                .ticketingTime(ticketingReservations.ticketingAt())
+                                                .build())
+                        .toList();
         ticketingAlertRepository.saveAll(alertsToAdd);
 
         return alertsToAdd.stream().map(TicketingAlert::getAlertTime).toList();
     }
 
     private List<LocalDateTime> removeAlerts(
-        TicketingReservationMessageDomainRequest ticketingReservations
-    ) {
-        List<TicketingAlert> existingAlerts = ticketingAlertRepository.findAllByUserFcmTokenAndShowIdAndIsDeletedFalse(
-            ticketingReservations.userFcmToken(),
-            ticketingReservations.showId()
-        );
+            TicketingReservationMessageDomainRequest ticketingReservations) {
+        List<TicketingAlert> existingAlerts =
+                ticketingAlertRepository.findAllByUserIdAndShowIdAndIsDeletedFalse(
+                        ticketingReservations.userId(), ticketingReservations.showId());
 
-        List<TicketingAlert> alertsToRemove = existingAlerts.stream()
-            .filter(alert -> ticketingReservations.deleteAlertAts().contains(alert.getAlertTime()))
-            .toList();
+        List<TicketingAlert> alertsToRemove =
+                existingAlerts.stream()
+                        .filter(
+                                alert ->
+                                        ticketingReservations
+                                                .deleteAlertAts()
+                                                .contains(alert.getAlertTime()))
+                        .toList();
         alertsToRemove.forEach(BaseEntity::softDelete);
 
         return alertsToRemove.stream().map(TicketingAlert::getAlertTime).toList();

--- a/app/domain/ticketing-domain/src/main/java/org/example/usecase/TicketingAlertUseCase.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/usecase/TicketingAlertUseCase.java
@@ -24,47 +24,49 @@ public class TicketingAlertUseCase {
 
     public List<TicketingAlertToSchedulerDomainResponse> findAllTicketingAlerts() {
         Map<TicketingAlertTargetDomainResponse, List<LocalDateTime>> groupedAlerts =
-                ticketingAlertRepository
-                        .findAllByIsDeletedFalseAndAlertTimeAfter(LocalDateTime.now())
-                        .stream()
-                        .collect(
-                                Collectors.groupingBy(
-                                        TicketingAlertTargetDomainResponse::from,
-                                        Collectors.mapping(
-                                                TicketingAlert::getAlertTime,
-                                                Collectors.toList())));
+            ticketingAlertRepository
+                .findAllByIsDeletedFalseAndAlertTimeAfter(LocalDateTime.now())
+                .stream()
+                .collect(
+                    Collectors.groupingBy(
+                        TicketingAlertTargetDomainResponse::from,
+                        Collectors.mapping(
+                            TicketingAlert::getAlertTime,
+                                    Collectors.toList()
+                        )
+                    ));
 
         return groupedAlerts.entrySet().stream()
-                .map(
-                        entry ->
-                                TicketingAlertToSchedulerDomainResponse.as(
-                                        entry.getKey(), entry.getValue()))
-                .toList();
+            .map(entry -> TicketingAlertToSchedulerDomainResponse.as(
+                    entry.getKey(),
+                    entry.getValue()
+                )
+            )
+            .toList();
     }
 
     @Transactional
     public TicketingAlertToSchedulerDomainResponse reserveTicketingAlert(
-            TicketingReservationMessageDomainRequest ticketingReservations) {
+        TicketingReservationMessageDomainRequest ticketingReservations
+    ) {
         return TicketingAlertToSchedulerDomainResponse.as(
-                ticketingReservations,
-                addAlerts(ticketingReservations),
-                removeAlerts(ticketingReservations));
+            ticketingReservations,
+            addAlerts(ticketingReservations),
+            removeAlerts(ticketingReservations));
     }
 
     private List<LocalDateTime> addAlerts(
             TicketingReservationMessageDomainRequest ticketingReservations) {
-        List<TicketingAlert> alertsToAdd =
-                ticketingReservations.addAlertAts().stream()
-                        .map(
-                                addAt ->
-                                        TicketingAlert.builder()
-                                                .name(ticketingReservations.name())
-                                                .alertTime(addAt)
-                                                .userId(ticketingReservations.userId())
-                                                .showId(ticketingReservations.showId())
-                                                .ticketingTime(ticketingReservations.ticketingAt())
-                                                .build())
-                        .toList();
+        List<TicketingAlert> alertsToAdd = ticketingReservations.addAlertAts().stream()
+            .map(addAt -> TicketingAlert.builder()
+                .name(ticketingReservations.name())
+                .alertTime(addAt)
+                .userId(ticketingReservations.userId())
+                .showId(ticketingReservations.showId())
+                .ticketingTime(ticketingReservations.ticketingAt())
+                .build()
+            )
+            .toList();
         ticketingAlertRepository.saveAll(alertsToAdd);
 
         return alertsToAdd.stream().map(TicketingAlert::getAlertTime).toList();
@@ -73,17 +75,13 @@ public class TicketingAlertUseCase {
     private List<LocalDateTime> removeAlerts(
             TicketingReservationMessageDomainRequest ticketingReservations) {
         List<TicketingAlert> existingAlerts =
-                ticketingAlertRepository.findAllByUserIdAndShowIdAndIsDeletedFalse(
-                        ticketingReservations.userId(), ticketingReservations.showId());
+            ticketingAlertRepository.findAllByUserIdAndShowIdAndIsDeletedFalse(
+                ticketingReservations.userId(), ticketingReservations.showId());
 
         List<TicketingAlert> alertsToRemove =
-                existingAlerts.stream()
-                        .filter(
-                                alert ->
-                                        ticketingReservations
-                                                .deleteAlertAts()
-                                                .contains(alert.getAlertTime()))
-                        .toList();
+            existingAlerts.stream()
+                .filter(alert -> ticketingReservations.deleteAlertAts().contains(alert.getAlertTime()))
+                .toList();
         alertsToRemove.forEach(BaseEntity::softDelete);
 
         return alertsToRemove.stream().map(TicketingAlert::getAlertTime).toList();


### PR DESCRIPTION
## 😋 작업한 내용

- TicketingAlert JPA 엔티티의 userFcmToken 제거 및 userId 추가
- userFcmToken 사용 로직 userId 사용하도록 수정
- 잘못된 패키지명(오타: listner -> listener) 1건 수정

## 🙏 PR Point

- quartz 의 경우 `ticketingAlertScheduler.addJob(jobDetail, true, true);` 에서 첫 번째 boolean 매개변수 값이 true 라면 같은 key를 갖는 job이 이미 있다면 replace 해줌. 즉, key 만 동일하게 넣어주면 무조건 새로운 알림 스케줄링을 하면서 예외처리 하고자 했던 부분이 모두 해소됨
  - key 의 userFcmToken 사용 부분을 userId로 변경함
- 아래는 Quartz 내부 코드
<img width="892" alt="스크린샷 2025-01-28 오후 7 59 00" src="https://github.com/user-attachments/assets/526b16c6-7a27-4638-a687-cfbd729f599f" />
<img width="559" alt="스크린샷 2025-01-28 오후 8 09 32" src="https://github.com/user-attachments/assets/78efbc0f-7964-4011-92a5-86de90adbe03" />


## 👍 관련 이슈

- Resolved : #18 


---