### PR TITLE
feat: FCM 토큰 변경시 알림 서버 티켓팅 알림 적용

### DIFF
--- a/app/api/common-api/src/main/java/org/example/listner/UpdateUserFcmTokenListener.java
+++ b/app/api/common-api/src/main/java/org/example/listner/UpdateUserFcmTokenListener.java
@@ -3,6 +3,7 @@ package org.example.listner;
 import lombok.RequiredArgsConstructor;
 import org.example.conver.UserMessageConverter;
 import org.example.metric.MessageQueueSubMonitored;
+import org.example.service.UserAlertService;
 import org.example.service.UserSubscriptionService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.connection.Message;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Controller;
 public class UpdateUserFcmTokenListener implements MessageListener {
 
     private final UserSubscriptionService userSubscriptionServiceImpl;
+    private final UserAlertService userAlertServiceImpl;
 
     @Override
     @MessageQueueSubMonitored(topic = "updateUserFcmToken")
@@ -22,5 +24,6 @@ public class UpdateUserFcmTokenListener implements MessageListener {
         var request = UserMessageConverter.toUserFcmMessage(message);
 
         userSubscriptionServiceImpl.updateUserFcmToken(request);
+        userAlertServiceImpl.updateUserFcmToken(request);
     }
 }

--- a/app/api/common-api/src/main/java/org/example/service/UserAlertService.java
+++ b/app/api/common-api/src/main/java/org/example/service/UserAlertService.java
@@ -1,0 +1,8 @@
+package org.example.service;
+
+import org.example.conver.message.UserFcmTokenMessage;
+
+public interface UserAlertService {
+
+    void updateUserFcmToken(UserFcmTokenMessage request);
+}

--- a/app/api/ticketing-api/src/main/java/org/example/batch/TicketingAlertBatch.java
+++ b/app/api/ticketing-api/src/main/java/org/example/batch/TicketingAlertBatch.java
@@ -1,9 +1,12 @@
 package org.example.batch;
 
+import java.util.List;
+import org.example.entity.TicketingAlert;
 import org.example.service.dto.response.TicketingAlertServiceRequest;
 
 public interface TicketingAlertBatch {
 
     void reserveTicketingAlerts(TicketingAlertServiceRequest ticketingAlert);
 
+    void updateTicketingAlerts(String userFcmToken, List<TicketingAlert> ticketingAlerts);
 }

--- a/app/api/ticketing-api/src/main/java/org/example/service/UserAlertServiceImpl.java
+++ b/app/api/ticketing-api/src/main/java/org/example/service/UserAlertServiceImpl.java
@@ -1,0 +1,18 @@
+package org.example.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.conver.message.UserFcmTokenMessage;
+import org.example.usecase.TicketingAlertUseCase;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserAlertServiceImpl implements UserAlertService {
+
+    private final TicketingAlertUseCase ticketingAlertUseCase;
+
+    @Override
+    public void updateUserFcmToken(UserFcmTokenMessage request) {
+        ticketingAlertUseCase.updateUserFcmToken(request.previousFcmToken(), request.updatedFcmToken());
+    }
+}

--- a/app/api/ticketing-api/src/main/java/org/example/service/UserAlertServiceImpl.java
+++ b/app/api/ticketing-api/src/main/java/org/example/service/UserAlertServiceImpl.java
@@ -1,7 +1,10 @@
 package org.example.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.example.batch.TicketingAlertBatch;
 import org.example.conver.message.UserFcmTokenMessage;
+import org.example.entity.TicketingAlert;
 import org.example.usecase.TicketingAlertUseCase;
 import org.springframework.stereotype.Service;
 
@@ -10,9 +13,14 @@ import org.springframework.stereotype.Service;
 public class UserAlertServiceImpl implements UserAlertService {
 
     private final TicketingAlertUseCase ticketingAlertUseCase;
+    private final TicketingAlertBatch ticketingAlertBatchComponent;
 
     @Override
     public void updateUserFcmToken(UserFcmTokenMessage request) {
-        ticketingAlertUseCase.updateUserFcmToken(request.previousFcmToken(), request.updatedFcmToken());
+        List<TicketingAlert> ticketingAlerts = ticketingAlertUseCase.updateUserFcmToken(
+            request.previousFcmToken(), request.updatedFcmToken());
+
+        ticketingAlertBatchComponent.updateTicketingAlerts(
+            request.previousFcmToken(), ticketingAlerts);
     }
 }

--- a/app/batch/src/main/java/org/example/component/TicketingAlertBatchComponent.java
+++ b/app/batch/src/main/java/org/example/component/TicketingAlertBatchComponent.java
@@ -6,9 +6,11 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.example.batch.TicketingAlertBatch;
 import org.example.dto.response.TicketingAlertToSchedulerDomainResponse;
+import org.example.entity.TicketingAlert;
 import org.example.job.TicketingAlertQuartzJob;
 import org.example.service.dto.response.TicketingAlertServiceRequest;
 import org.example.usecase.TicketingAlertUseCase;
@@ -42,22 +44,27 @@ public class TicketingAlertBatchComponent implements TicketingAlertBatch {
     @Override
     public void reserveTicketingAlerts(TicketingAlertServiceRequest ticketingAlert) {
         try {
-            JobKey jobKey = getJobKey(ticketingAlert);
+            JobKey jobKey = getJobKey(ticketingAlert.userFcmToken(), ticketingAlert.showId());
             boolean jobExists = ticketingAlertScheduler.checkExists(jobKey);
 
             if (!jobExists) {
-                JobDetail jobDetail = getJobDetail(ticketingAlert);
+                JobDetail jobDetail = getJobDetail(ticketingAlert.userFcmToken(),
+                    ticketingAlert.name(), ticketingAlert.showId());
                 ticketingAlertScheduler.addJob(jobDetail, true, true);
             }
 
             List<TriggerKey> triggerKeysToRemove = ticketingAlert.deleteAlertAts().stream()
-                .map(alertTime -> getTriggerKey(ticketingAlert, alertTime))
+                .map(alertTime ->
+                    getTriggerKey(ticketingAlert.userFcmToken(), ticketingAlert.showId(),
+                        ticketingAlert.ticketingAt(), alertTime))
                 .toList();
             ticketingAlertScheduler.unscheduleJobs(triggerKeysToRemove);
 
             for (LocalDateTime alertTime : ticketingAlert.addAlertAts()) {
                 Trigger trigger = TriggerBuilder.newTrigger()
-                    .withIdentity(getTriggerKey(ticketingAlert, alertTime))
+                    .withIdentity(
+                        getTriggerKey(ticketingAlert.userFcmToken(), ticketingAlert.showId(),
+                            ticketingAlert.ticketingAt(), alertTime))
                     .startAt(Date.from(alertTime.atZone(ZoneId.systemDefault()).toInstant()))
                     .forJob(jobKey)
                     .build();
@@ -69,15 +76,54 @@ public class TicketingAlertBatchComponent implements TicketingAlertBatch {
         }
     }
 
+    @Override
+    public void updateTicketingAlerts(
+        String previousFcmToken,
+        List<TicketingAlert> ticketingAlerts) {
+        try {
+            List<TriggerKey> triggerKeysToRemove = ticketingAlerts.stream()
+                .map(ticketingAlert ->
+                    getTriggerKey(previousFcmToken, ticketingAlert.getShowId(),
+                        ticketingAlert.getTicketingTime(), ticketingAlert.getAlertTime()))
+                .toList();
+            ticketingAlertScheduler.unscheduleJobs(triggerKeysToRemove);
+
+            for (TicketingAlert ticketingAlert : ticketingAlerts) {
+                JobDetail jobDetail = getJobDetail(ticketingAlert.getUserFcmToken(),
+                    ticketingAlert.getName(), ticketingAlert.getShowId());
+                ticketingAlertScheduler.addJob(jobDetail, true, true);
+
+                Trigger trigger = TriggerBuilder.newTrigger()
+                    .withIdentity(
+                        getTriggerKey(ticketingAlert.getUserFcmToken(), ticketingAlert.getShowId(),
+                            ticketingAlert.getTicketingTime(), ticketingAlert.getAlertTime()))
+                    .startAt(Date.from(
+                        ticketingAlert.getAlertTime().atZone(ZoneId.systemDefault()).toInstant()))
+                    .forJob(
+                        getJobDetail(ticketingAlert.getUserFcmToken(), ticketingAlert.getName(),
+                            ticketingAlert.getShowId()))
+                    .build();
+
+                System.out.println(ticketingAlert.getUserFcmToken());
+
+                ticketingAlertScheduler.scheduleJob(trigger);
+            }
+        } catch (SchedulerException e) {
+            throw new IllegalStateException(e.getMessage(), e);
+        }
+    }
+
     private TriggerKey getTriggerKey(
-        TicketingAlertServiceRequest ticketingAlert,
+        String userFcmToken,
+        UUID showId,
+        LocalDateTime ticketingAt,
         LocalDateTime alertTime
     ) {
         return TriggerKey.triggerKey(
-            ticketingAlert.userFcmToken() + " : "
-                + ticketingAlert.showId() + " : "
+            userFcmToken + " : "
+                + showId + " : "
                 + alertTime,
-            calculateAlertMinutes(alertTime, ticketingAlert.ticketingAt())
+            calculateAlertMinutes(alertTime, ticketingAt)
         );
     }
 
@@ -85,13 +131,13 @@ public class TicketingAlertBatchComponent implements TicketingAlertBatch {
         return String.valueOf(Duration.between(alertTime, ticketingAt).toMinutes());
     }
 
-    private JobDetail getJobDetail(TicketingAlertServiceRequest ticketingAlert) {
-        JobKey jobKey = getJobKey(ticketingAlert);
+    private JobDetail getJobDetail(String userFcmToken, String name, UUID showId) {
+        JobKey jobKey = getJobKey(userFcmToken, showId);
 
         JobDataMap jobDataMap = new JobDataMap();
-        jobDataMap.put("userFcmToken", ticketingAlert.userFcmToken());
-        jobDataMap.put("name", ticketingAlert.name());
-        jobDataMap.put("showId", ticketingAlert.showId().toString());
+        jobDataMap.put("userFcmToken", userFcmToken);
+        jobDataMap.put("name", name);
+        jobDataMap.put("showId", showId.toString());
         jobDataMap.put("retryCount", 0);
 
         return JobBuilder.newJob(TicketingAlertQuartzJob.class)
@@ -100,10 +146,7 @@ public class TicketingAlertBatchComponent implements TicketingAlertBatch {
             .build();
     }
 
-    private JobKey getJobKey(TicketingAlertServiceRequest ticketingAlert) {
-        return new JobKey(
-            ticketingAlert.userFcmToken() + " : "
-                + ticketingAlert.showId()
-        );
+    private JobKey getJobKey(String userFcmToken, UUID showId) {
+        return new JobKey(userFcmToken + " : " + showId);
     }
 }

--- a/app/domain/alarm-domain/src/main/java/org/example/repository/alarm/ShowAlarmQuerydslRepositoryImpl.java
+++ b/app/domain/alarm-domain/src/main/java/org/example/repository/alarm/ShowAlarmQuerydslRepositoryImpl.java
@@ -39,7 +39,8 @@ public class ShowAlarmQuerydslRepositoryImpl implements ShowAlarmQuerydslReposit
                 )
             )
             .from(showAlarm)
-            .where(getDefaultPredicateInCursorPagination(request.cursorId(), request.cursorValue()))
+            .where(getDefaultPredicateInCursorPagination(request.fcmToken(), request.cursorId(),
+                request.cursorValue()))
             .orderBy(
                 showAlarm.createdAt.desc(),
                 showAlarm.id.asc()
@@ -59,10 +60,12 @@ public class ShowAlarmQuerydslRepositoryImpl implements ShowAlarmQuerydslReposit
     }
 
     private Predicate getDefaultPredicateInCursorPagination(
+        String fcmToken,
         UUID cursorId,
         LocalDateTime cursorValue
     ) {
-        BooleanExpression wherePredicate = showAlarm.isDeleted.isFalse();
+        BooleanExpression wherePredicate = showAlarm.userFcmToken.eq(fcmToken)
+            .and(showAlarm.isDeleted.isFalse());
         if (cursorId != null && cursorValue != null) {
             wherePredicate = wherePredicate.and(
                 showAlarm.createdAt.lt(cursorValue)

--- a/app/domain/ticketing-domain/src/main/java/org/example/entity/TicketingAlert.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/entity/TicketingAlert.java
@@ -45,4 +45,8 @@ public class TicketingAlert extends BaseEntity {
         this.showId = showId;
         this.ticketingTime = ticketingTime;
     }
+
+    public void updateUserFcmToken(String userFcmToken) {
+        this.userFcmToken = userFcmToken;
+    }
 }

--- a/app/domain/ticketing-domain/src/main/java/org/example/repository/ticketingalert/TicketingAlertQuerydslRepository.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/repository/ticketingalert/TicketingAlertQuerydslRepository.java
@@ -1,0 +1,10 @@
+package org.example.repository.ticketingalert;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.example.entity.TicketingAlert;
+
+public interface TicketingAlertQuerydslRepository {
+
+    List<TicketingAlert> findAllByFcmTokenAndAlertTimeAfterNow(String fcmToken, LocalDateTime now);
+}

--- a/app/domain/ticketing-domain/src/main/java/org/example/repository/ticketingalert/TicketingAlertQuerydslRepositoryImpl.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/repository/ticketingalert/TicketingAlertQuerydslRepositoryImpl.java
@@ -1,0 +1,29 @@
+
+package org.example.repository.ticketingalert;
+
+import static org.example.entity.QTicketingAlert.ticketingAlert;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.example.entity.TicketingAlert;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TicketingAlertQuerydslRepositoryImpl implements
+    TicketingAlertQuerydslRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+
+    @Override
+    public List<TicketingAlert> findAllByFcmTokenAndAlertTimeAfterNow(String fcmToken, LocalDateTime now) {
+        return jpaQueryFactory.selectFrom(ticketingAlert)
+            .where(ticketingAlert.userFcmToken.eq(fcmToken)
+                .and(ticketingAlert.alertTime.after(now))
+                .and(ticketingAlert.isDeleted.isFalse()))
+            .stream().toList();
+    }
+}

--- a/app/domain/ticketing-domain/src/main/java/org/example/repository/ticketingalert/TicketingAlertRepository.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/repository/ticketingalert/TicketingAlertRepository.java
@@ -6,7 +6,8 @@ import java.util.UUID;
 import org.example.entity.TicketingAlert;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TicketingAlertRepository extends JpaRepository<TicketingAlert, UUID> {
+public interface TicketingAlertRepository extends JpaRepository<TicketingAlert, UUID>,
+    TicketingAlertQuerydslRepository {
 
     List<TicketingAlert> findAllByUserFcmTokenAndShowIdAndIsDeletedFalse(
         String userFcmToken,

--- a/app/domain/ticketing-domain/src/main/java/org/example/usecase/TicketingAlertUseCase.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/usecase/TicketingAlertUseCase.java
@@ -42,6 +42,12 @@ public class TicketingAlertUseCase {
     }
 
     @Transactional
+    public void updateUserFcmToken(String previousFcmToken, String updatedFcmToken) {
+        ticketingAlertRepository.findAllByFcmTokenAndAlertTimeAfterNow(previousFcmToken, LocalDateTime.now())
+            .forEach(ticketingAlert -> ticketingAlert.updateUserFcmToken(updatedFcmToken));
+    }
+
+    @Transactional
     public TicketingAlertToSchedulerDomainResponse reserveTicketingAlert(
         TicketingReservationMessageDomainRequest ticketingReservations
     ) {

--- a/app/domain/ticketing-domain/src/main/java/org/example/usecase/TicketingAlertUseCase.java
+++ b/app/domain/ticketing-domain/src/main/java/org/example/usecase/TicketingAlertUseCase.java
@@ -42,9 +42,15 @@ public class TicketingAlertUseCase {
     }
 
     @Transactional
-    public void updateUserFcmToken(String previousFcmToken, String updatedFcmToken) {
-        ticketingAlertRepository.findAllByFcmTokenAndAlertTimeAfterNow(previousFcmToken, LocalDateTime.now())
-            .forEach(ticketingAlert -> ticketingAlert.updateUserFcmToken(updatedFcmToken));
+    public List<TicketingAlert> updateUserFcmToken(
+        String previousFcmToken,
+        String updatedFcmToken) {
+        List<TicketingAlert> ticketingAlerts = ticketingAlertRepository.findAllByFcmTokenAndAlertTimeAfterNow(
+            previousFcmToken, LocalDateTime.now());
+        ticketingAlerts.forEach(
+            ticketingAlert -> ticketingAlert.updateUserFcmToken(updatedFcmToken));
+
+        return ticketingAlerts;
     }
 
     @Transactional


### PR DESCRIPTION
## 😋 작업한 내용

- FCM 토큰 변경 시 알림 서버의 티켓팅 알림에서의 FCM을 변경해줍니다.
- Spring Quartz의 메모리의 알림을 다시 설정해줍니다. 
- 알림 목록 조회시 FCM을 통한 조건절 추가

## 🙏 PR Point

- 내부 로직
- 변수 명

## 👍 관련 이슈

- Resolved : https://showpot.atlassian.net/browse/SPT-44


---